### PR TITLE
Integration with cohttp-lwt (client)

### DIFF
--- a/src/integrations/cohttp/opentelemetry_cohttp_lwt.ml
+++ b/src/integrations/cohttp/opentelemetry_cohttp_lwt.ml
@@ -19,7 +19,7 @@ module Server : sig
               (Server.make () ~callback:callback_traced)
    *)
   val trace :
-    service_name:string ->
+    ?service_name:string ->
     ?attrs:Otel.Span.key_value list ->
     ('conn -> Request.t -> 'body -> (Response.t * 'body) Lwt.t) ->
     'conn -> Request.t -> 'body -> (Response.t * 'body) Lwt.t
@@ -112,11 +112,11 @@ end = struct
     let headers = Header.remove (Request.headers req) header_x_ocaml_otel_traceparent in
     { req with headers }
 
-  let trace ~service_name ?(attrs=[]) callback =
+  let trace ?service_name ?(attrs=[]) callback =
     fun conn req body ->
     let scope = get_trace_context ~from:`External req in
     Otel_lwt.Trace.with_
-      ~service_name
+      ?service_name
       "request"
       ~kind:Span_kind_server
       ?trace_id:(Option.map (fun scope -> scope.Otel.Trace.trace_id) scope)

--- a/tests/bin/cohttp_client.ml
+++ b/tests/bin/cohttp_client.ml
@@ -1,0 +1,59 @@
+module T = Opentelemetry
+module Otel_lwt = Opentelemetry_lwt
+let spf = Printf.sprintf
+let (let@) f x = f x
+
+let sleep_inner = ref 0.1
+let sleep_outer = ref 2.0
+
+let mk_client ~scope = Opentelemetry_cohttp_lwt.client ~scope (module Cohttp_lwt_unix.Client)
+
+let run () =
+  Printf.printf "collector is on %S\n%!" (Opentelemetry_client_ocurl.get_url());
+  let open Lwt.Syntax in
+  let rec go () =
+    let@ scope =
+      Otel_lwt.Trace.with_
+        ~kind:T.Span.Span_kind_producer
+        "loop.outer"
+    in
+    let* () = Lwt_unix.sleep !sleep_outer in
+    let module C = (val mk_client ~scope) in
+    let* (res, body) = C.get (Uri.of_string "https://enec1hql02hz.x.pipedream.net") in
+    let* () = Cohttp_lwt.Body.drain_body body in
+    go ()
+  in
+  go ()
+
+let () =
+  Sys.catch_break true;
+  T.Globals.service_name := "ocaml-otel-cohttp-client";
+  T.Globals.service_namespace := Some "ocaml-otel.test";
+
+  let debug = ref false in
+  let thread = ref true in
+  let batch_traces = ref 400 in
+  let batch_metrics = ref 3 in
+  let opts = [
+      "--debug", Arg.Bool ((:=) debug), " enable debug output";
+      "--thread", Arg.Bool ((:=) thread), " use a background thread";
+      "--batch-traces", Arg.Int ((:=) batch_traces), " size of traces batch";
+      "--batch-metrics", Arg.Int ((:=) batch_metrics), " size of metrics batch";
+      "--sleep-inner", Arg.Set_float sleep_inner, " sleep (in s) in inner loop";
+      "--sleep-outer", Arg.Set_float sleep_outer, " sleep (in s) in outer loop";
+    ] |> Arg.align in
+
+  Arg.parse opts (fun _ -> ()) "emit1 [opt]*";
+
+  let some_if_nzero r = if !r > 0 then Some !r else None in
+  let config = Opentelemetry_client_ocurl.Config.make
+                 ~debug:!debug
+                 ~batch_traces:(some_if_nzero batch_traces)
+                 ~batch_metrics:(some_if_nzero batch_metrics)
+                 ~thread:!thread () in
+  Format.printf "@[<2>sleep outer: %.3fs,@ sleep inner: %.3fs,@ config: %a@]@."
+    !sleep_outer !sleep_inner Opentelemetry_client_ocurl.Config.pp config;
+
+  Format.printf "Check HTTP requests at https://requestbin.com/r/enec1hql02hz/26qShWryt5vJc1JfrOwalhr5vQt@.";
+
+  Opentelemetry_client_ocurl.with_setup ~config () (fun () -> Lwt_main.run (run ()))

--- a/tests/bin/dune
+++ b/tests/bin/dune
@@ -1,3 +1,9 @@
 (executable
  (name emit1)
+ (modules emit1)
  (libraries unix opentelemetry opentelemetry-client-ocurl))
+
+(executable
+ (name cohttp_client)
+ (modules cohttp_client)
+ (libraries cohttp-lwt-unix opentelemetry opentelemetry-client-ocurl opentelemetry-cohttp-lwt))


### PR DESCRIPTION
API for discussion. The idea is that you call `Opentelemetry_cohttp_lwt.client` and it gives you back a traced version of `Cohttp_lwt.Client`.

The downside is that you have to do this at every call to include the current scope:

```ocaml
let mk_client ?scope () =
  Opentelemetry_cohttp_lwt.client ?scope (module Cohttp_lwt_unix.Client)

let f ~scope =
  let (module C) = mk_client ~scope () in
  C.get (Uri.of_string "https://google.com")
```

The upside is that you can trace calls made with `Cohttp_lwt` in 3rd party libraries without those libraries knowing about `Opentelemetry`, as long as those libraries are functorized over `Cohttp_lwt.S.Client`.

See for example https://github.com/AestheticIntegration/ocaml-kubernetes/commit/f0d74fb72c399edc6f153702f4e197911901ba85:

```ocaml
let f ~scope ~config ~ns = 
  let (module C) = mk_client ~scope () in
  let module Kube_api = Kubernetes.Api.Make(C) in
  Kube_api.V1.Namespaces.Pod.list config ~ns ()
```