### PR TITLE
feat: use runtime metric conventions; add runtime attributes

### DIFF
--- a/src/client/opentelemetry_client_ocurl.ml
+++ b/src/client/opentelemetry_client_ocurl.ml
@@ -47,7 +47,9 @@ let gc_metrics = AList.make() (* side channel for GC, appended to {!E_metrics}'s
    collection *)
 let sample_gc_metrics () =
   Atomic.set needs_gc_metrics false;
-  let l = OT.Metrics.make_resource_metrics @@ Opentelemetry.GC_metrics.get_metrics() in
+  let l = OT.Metrics.make_resource_metrics
+            ~attrs:(Opentelemetry.GC_metrics.get_runtime_attributes ())
+          @@ Opentelemetry.GC_metrics.get_metrics() in
   AList.add gc_metrics l
 
 let lock_ : (unit -> unit) ref = ref ignore


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/runtime-environment-metrics.md#runtime-environment-specific-metrics---processruntimeenvironment